### PR TITLE
Reverting to HF pipeline 

### DIFF
--- a/app.py
+++ b/app.py
@@ -110,8 +110,6 @@ class DistilWhisperWrapper(ClamsApp):
                 new_view.new_contain(AnnotationTypes.Alignment)
 
                 result = pipe(resampled_audio_fname, return_timestamps=True)
-
-                # result = pipe(resampled_audio_fname, return_timestamps=True)
                 output_text = result["text"]
                 text_document: Document = new_view.new_textdocument(text=output_text)
                 new_view.new_annotation(AnnotationTypes.Alignment, source=doc.long_id, target=text_document.long_id)

--- a/app.py
+++ b/app.py
@@ -60,10 +60,13 @@ class DistilWhisperWrapper(ClamsApp):
             model=model,
             tokenizer=processor.tokenizer,
             feature_extractor=processor.feature_extractor,
-            max_new_tokens=128,
+            max_new_tokens=256,
             chunk_length_s=25,
             torch_dtype=torch_dtype,
             device=device,
+            generate_kwargs={
+                'forced_decoder_ids': None,
+            }
         )
 
         # try to get AudioDocuments
@@ -107,6 +110,8 @@ class DistilWhisperWrapper(ClamsApp):
                 new_view.new_contain(AnnotationTypes.Alignment)
 
                 result = pipe(resampled_audio_fname, return_timestamps=True)
+
+                # result = pipe(resampled_audio_fname, return_timestamps=True)
                 output_text = result["text"]
                 text_document: Document = new_view.new_textdocument(text=output_text)
                 new_view.new_annotation(AnnotationTypes.Alignment, source=doc.long_id, target=text_document.long_id)

--- a/app.py
+++ b/app.py
@@ -114,7 +114,11 @@ class DistilWhisperWrapper(ClamsApp):
                     sentence = new_view.new_annotation(Uri.SENTENCE, text=chunk['text'])
                     time = chunk["timestamp"]
                     s = int(time[0] * 1000)
-                    e = int(time[1] * 1000)
+                    if time[1] is None:
+                        probe = ffmpeg.probe(video_path)
+                        e = int(float(probe['streams'][0]['duration']) * 1000)
+                    else:
+                        e = int(time[1] * 1000)
                     tf = new_view.new_annotation(AnnotationTypes.TimeFrame, frameType="speech", timeUnit="milliseconds", start=s, end=e)
                     new_view.new_annotation(AnnotationTypes.Alignment, source=tf.long_id, target=sentence.long_id)
         return mmif

--- a/app.py
+++ b/app.py
@@ -17,44 +17,17 @@ from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor, pipeline
 # Import needs for processing video file
 import tempfile
 import ffmpeg
-import torchaudio
-
-
-def process_output_with_enclosed_timestamps(output):
-    segments = []
-    raw_segments = output[0].split("<|")
-    for i in range(1, len(raw_segments), 2):
-        start_segment = raw_segments[i].split("|>")
-        end_segment = raw_segments[i + 1].split("|>") if i + 1 < len(raw_segments) else ["", ""]
-        if len(start_segment) == 2 and len(end_segment) >= 1:
-            start_timestamp = int(float(start_segment[0]) * 1000)
-            text = start_segment[1]
-            end_timestamp = int(float(end_segment[0]) * 1000)
-            segments.append((start_timestamp, end_timestamp, text))
-    return segments
-
-
-def audio_duration_is_long(file_path):
-    try:
-        probe = ffmpeg.probe(file_path)
-        duration = float(probe['streams'][0]['duration'])
-        if duration > 30:
-            return True
-        else:
-            return False
-    except ffmpeg.Error as e:
-        print(f"An error occurred: {e.stderr.decode()}")
-        return False
 
 
 class DistilWhisperWrapper(ClamsApp):
+
     model_size_alias = {
-        'small': 'distil-small.en',
-        's': 'distil-small.en',
-        'medium': 'distil-medium.en',
-        'm': 'distil-medium.en',
-        'large-v2': 'distil-large-v2',
-        'l2': 'distil-large-v2',
+        'small': 'distil-small.en', 
+        's': 'distil-small.en', 
+        'medium': 'distil-medium.en', 
+        'm': 'distil-medium.en', 
+        'large-v2': 'distil-large-v2', 
+        'l2': 'distil-large-v2', 
         'large-v3': 'distil-large-v3',
         'l3': 'distil-large-v3'
     }
@@ -82,92 +55,70 @@ class DistilWhisperWrapper(ClamsApp):
         model = AutoModelForSpeechSeq2Seq.from_pretrained(model_id, torch_dtype=torch_dtype, low_cpu_mem_usage=True, use_safetensors=True)
         model.to(device)
         processor = AutoProcessor.from_pretrained(model_id)
+        pipe = pipeline(
+            "automatic-speech-recognition",
+            model=model,
+            tokenizer=processor.tokenizer,
+            feature_extractor=processor.feature_extractor,
+            max_new_tokens=128,
+            chunk_length_s=25,
+            torch_dtype=torch_dtype,
+            device=device,
+        )
 
-        # get the file path
+        # try to get AudioDocuments
         docs = mmif.get_documents_by_type(DocumentTypes.AudioDocument)
         if docs:
-            doc = docs[0]
-            target_path = doc.location_path(nonexist_ok=False)
+            for doc in docs:
+                file_path = doc.location_path(nonexist_ok=False)
+                new_view = mmif.new_view()
+                self.sign_view(new_view, parameters)
+                new_view.new_contain(DocumentTypes.TextDocument, document=doc.long_id)
+                new_view.new_contain(AnnotationTypes.TimeFrame, timeUnit="milliseconds", document=doc.long_id)
+                new_view.new_contain(AnnotationTypes.Alignment)
+
+                result = pipe(file_path, return_timestamps=True)
+                output_text = result["text"]
+                text_document: Document = new_view.new_textdocument(text=output_text)
+                new_view.new_annotation(AnnotationTypes.Alignment, source=doc.long_id, target=text_document.long_id)
+                for chunk in result["chunks"]:
+                    sentence = new_view.new_annotation(Uri.SENTENCE, text=chunk['text'])
+                    time = chunk["timestamp"]
+                    s = int(time[0] * 1000)
+                    e = int(time[1] * 1000)
+                    tf = new_view.new_annotation(AnnotationTypes.TimeFrame, frameType="speech", start=s, end=e)
+                    new_view.new_annotation(AnnotationTypes.Alignment, source=tf.long_id, target=sentence.long_id)
+
+
+        # and if none found, try VideoDocuments
         else:
             docs = mmif.get_documents_by_type(DocumentTypes.VideoDocument)
-            doc = docs[0]
-            video_path = doc.location_path(nonexist_ok=False)
-            # transform the video file to audio file
-            audio_tmpdir = tempfile.TemporaryDirectory()
-            target_path = f'{audio_tmpdir.name}/{doc.id}_16kHz.wav'
-            ffmpeg.input(video_path).output(target_path, ac=1, ar=16000).run()
+            for doc in docs:
+                video_path = doc.location_path(nonexist_ok=False)
+                # transform the video file to audio file
+                audio_tmpdir = tempfile.TemporaryDirectory()
+                resampled_audio_fname = f'{audio_tmpdir.name}/{doc.id}_16kHz.wav'
+                ffmpeg.input(video_path).output(resampled_audio_fname, ac=1, ar=16000).run()
 
-        new_view = mmif.new_view()
-        self.sign_view(new_view, parameters)
-        new_view.new_contain(DocumentTypes.TextDocument, document=doc.long_id, _lang='en')
-        new_view.new_contain(AnnotationTypes.TimeFrame, timeUnit="milliseconds", document=doc.long_id)
-        new_view.new_contain(AnnotationTypes.Alignment)
-        new_view.new_contain(Uri.SENTENCE, document=doc.long_id)
+                new_view = mmif.new_view()
+                self.sign_view(new_view, parameters)
+                new_view.new_contain(DocumentTypes.TextDocument, document=doc.long_id)
+                new_view.new_contain(AnnotationTypes.TimeFrame, timeUnit="milliseconds", document=doc.long_id)
+                new_view.new_contain(AnnotationTypes.Alignment)
 
-        # model run on long form audio using the model + processor API directly
-        if audio_duration_is_long(target_path):
-            # process the audio into tensor
-            waveform, sampling_rate = torchaudio.load(target_path)
-            if sampling_rate != 16000:
-                resampler = torchaudio.transforms.Resample(orig_freq=sampling_rate, new_freq=16000)
-                waveform = resampler(waveform)
-                sampling_rate = 16000
-
-            inputs = processor(
-                waveform.squeeze().numpy(),  # Convert to numpy array and remove channel dimension if it's single-channel audio
-                sampling_rate=sampling_rate,
-                return_tensors="pt",  # Return PyTorch tensors
-                padding="longest",  # This might not be necessary for a single file, but it's here for consistency
-                return_attention_mask=True,
-                truncation=False
-            )
-            generate_kwargs = {
-                "max_new_tokens": 448,
-                "num_beams": 1,
-                "condition_on_prev_tokens": False,
-                "compression_ratio_threshold": 1.35,  # zlib compression ratio threshold (in token space)
-                "temperature": (0.0, 0.2, 0.4, 0.6, 0.8, 1.0),
-                "logprob_threshold": -1.0,
-                "no_speech_threshold": 0.6,
-                "return_timestamps": True,
-            }
-            inputs = inputs.to(device, dtype=torch_dtype)
-            pred_ids = model.generate(**inputs, **generate_kwargs)
-            pred_text = processor.batch_decode(pred_ids, skip_special_tokens=True, decode_with_timestamps=True)
-            processed_segments = process_output_with_enclosed_timestamps(pred_text)
-
-            td = ''.join(text for _, _, text in processed_segments)[1:]
-            text_document: Document = new_view.new_textdocument(text=td)
-            new_view.new_annotation(AnnotationTypes.Alignment, source=doc.long_id, target=text_document.long_id)
-            for segment in processed_segments:
-                sentence = new_view.new_annotation(Uri.SENTENCE, text=segment[2][1:])
-                tf = new_view.new_annotation(AnnotationTypes.TimeFrame, frameType="speech", start=segment[0], end=segment[1])
-                new_view.new_annotation(AnnotationTypes.Alignment, source=tf.long_id, target=sentence.long_id)
-
-        # model run on short form using pipeline
-        else:
-            pipe = pipeline(
-                "automatic-speech-recognition",
-                model=model,
-                tokenizer=processor.tokenizer,
-                feature_extractor=processor.feature_extractor,
-                max_new_tokens=128,
-                torch_dtype=torch_dtype,
-                device=device,
-            )
-            result = pipe(target_path, return_timestamps=True)
-            output_text = result["text"]
-            text_document: Document = new_view.new_textdocument(text=output_text)
-            new_view.new_annotation(AnnotationTypes.Alignment, source=doc.long_id, target=text_document.long_id)
-            for chunk in result["chunks"]:
-                sentence = new_view.new_annotation(Uri.SENTENCE, text=chunk['text'])
-                time = chunk["timestamp"]
-                s = int(time[0] * 1000)
-                e = int(time[1] * 1000)
-                tf = new_view.new_annotation(AnnotationTypes.TimeFrame, frameType="speech", start=s, end=e)
-                new_view.new_annotation(AnnotationTypes.Alignment, source=tf.long_id, target=sentence.long_id)
-
+                result = pipe(resampled_audio_fname, return_timestamps=True)
+                output_text = result["text"]
+                text_document: Document = new_view.new_textdocument(text=output_text)
+                new_view.new_annotation(AnnotationTypes.Alignment, source=doc.long_id, target=text_document.long_id)
+                for chunk in result["chunks"]:
+                    sentence = new_view.new_annotation(Uri.SENTENCE, text=chunk['text'])
+                    time = chunk["timestamp"]
+                    s = int(time[0] * 1000)
+                    e = int(time[1] * 1000)
+                    tf = new_view.new_annotation(AnnotationTypes.TimeFrame, frameType="speech", timeUnit="milliseconds", start=s, end=e)
+                    new_view.new_annotation(AnnotationTypes.Alignment, source=tf.long_id, target=sentence.long_id)
         return mmif
+
 
 
 def get_app():
@@ -178,6 +129,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--port", action="store", default="5000", help="set port to listen")
     parser.add_argument("--production", action="store_true", help="run gunicorn server")
+    # add more arguments as needed
+    # parser.add_argument(more_arg...)
 
     parsed_args = parser.parse_args()
 


### PR DESCRIPTION
This PR aims to resolve #1 

## Implementations
* reverted `app.py` to the original [commit](https://github.com/clamsproject/app-distil-whisper-wrapper/commit/45ce63965367c14d8da36dd460d7737ab5787db2), where we use chunking instead of sequential transcriptions. 
* All chunks are 25 seconds long, with a 4.167 [slide length](https://huggingface.co/docs/transformers/en/main_classes/pipelines)

## Edge Cases
* Sometimes the end timestamp of the final timeframe is None, which would cause a NoneType error later on. -> Solution: replace the None value with the length of the video because it's the final timestamp in the video.

## Discusion
* While the HF pipeline using chunking is expected to be [0.5%](https://github.com/huggingface/distil-whisper) less accurate than sequential timestamps, sequential transcriptions are unable to accurately predict timestamps in [long-form audio](https://huggingface.co/distil-whisper/distil-large-v3). That said, when I ran evaluations with a chunking HF pipeline, sequential HF pipeline, and the direct loading implementation, I got the average case-insensitive WER scores 0.20694108582670986, 0.27313541865137164, and 1.2794192594300127, respectively. This makes makes this current implementation, the chunking HF pipeline, significantly more accurate.
* Even when the sequential transcriptions were produced with a direct loading implementation to avoid this timeframe issues of the HF pipeline in long-form audio, this method would have bugs where three timestamps would be found in a row (see #1), which would cause much of the data to be lost in the output and the timeframes to be unclear in the MMIF files. Changing how we extracted the output wouldn't change the fact that we would have three timestamps in a row, effecting the documentation of the timeframes in the MMIF files.
* While we could hardcode the output to fix both the text and timeframe outputs into the MMIF, this likely still would not have as clear timeframes as the chunking method with the HF pipeline, which sometimes would have timeframes 3x smaller and are a little more accurate.